### PR TITLE
Add one big image with all dbt packages

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [gcp, aws]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,6 +33,5 @@ jobs:
         with:
           context: ./
           builder: ${{ steps.buildx.outputs.name }}
-          target: ${{ matrix.platform }}
           push: true
-          tags: gcr.io/getindata-images-public/dbt-dataops:${{ matrix.platform }}-${{ github.sha }}
+          tags: gcr.io/getindata-images-public/dbt-dataops:${{ github.sha }}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [gcp, aws]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -47,9 +44,8 @@ jobs:
         with:
           context: ./
           builder: ${{ steps.buildx.outputs.name }}
-          target: ${{ matrix.platform }}
           push: true
-          tags: gcr.io/getindata-images-public/${{ steps.tag-info.outputs.IMAGE_NAME }}:${{ matrix.platform }}-${{ steps.tag-info.outputs.IMAGE_VERSION }},gcr.io/getindata-images-public/${{ steps.tag-info.outputs.IMAGE_NAME }}:${{ matrix.platform }}-latest
+          tags: gcr.io/getindata-images-public/${{ steps.tag-info.outputs.IMAGE_NAME }}:${{ steps.tag-info.outputs.IMAGE_VERSION }},gcr.io/getindata-images-public/${{ steps.tag-info.outputs.IMAGE_NAME }}:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,3 @@ RUN pip install --upgrade pip setuptools wheel --no-cache-dir \
 WORKDIR /dbt
 ADD ./executor_with_test_reports_ingestions.sh /dbt/
 RUN chmod +x /dbt/executor_with_test_reports_ingestions.sh
-
-FROM base as gcp
-COPY requirements/requirements-gcp.txt ./
-RUN pip install -r requirements-gcp.txt
-
-FROM base as aws
-COPY requirements/requirements-aws.txt ./
-RUN pip install -r requirements-aws.txt

--- a/renovate.json
+++ b/renovate.json
@@ -35,16 +35,6 @@
           "addLabels": [
               "patch"
           ]
-      },
-      {
-          "description": "Automatically merge minor and patch-level updates",
-          "matchUpdateTypes": [
-              "minor",
-              "patch",
-              "digest"
-          ],
-          "automerge": true,
-          "automergeType": "branch"
       }
   ],
   "pip_requirements": {

--- a/requirements/requirements-aws.txt
+++ b/requirements/requirements-aws.txt
@@ -1,1 +1,0 @@
-dbt-redshift==1.3.0

--- a/requirements/requirements-gcp.txt
+++ b/requirements/requirements-gcp.txt
@@ -1,1 +1,0 @@
-dbt-bigquery==1.3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-acryl-datahub[dbt]>=0.8.39
+acryl-datahub[dbt]==0.8.43.2
 dbt-core==1.1.0
 dbt-redshift==1.1.0
 dbt-postgres==1.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,7 @@
-acryl-datahub[dbt]==0.9.2.4
-dbt-core==1.3.1
+acryl-datahub[dbt]>=0.8.39
+dbt-core==1.1.0
+dbt-redshift==1.1.0
+dbt-postgres==1.1.0
+dbt-bigquery==1.1.0
+dbt-snowflake==1.1.0
+dbt-spark==1.1.0


### PR DESCRIPTION
Changes:
* removed auto-merge on `renovate`
* removed platform matrix and requirements for gcp, aws
* added dbt packages/datahub cli with the same version that is in dp cli 
* image size increased from `231 MB` to `262.6 MB`